### PR TITLE
接続されているHokuyoのデバイスファイル名を列挙するスクリプトを作成した

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,12 @@
+Scripts
+=======
+
+* 接続されているHokuyoのデバイスファイル名を列挙する
+
+```
+# 実行方法
+$(rospack find ubiquitous_display)/scripts/list_hokuyo_devs.sh
+
+# 結果（1つだけ接続されている場合）
+/dev/ttyACM1
+```

--- a/scripts/list_hokuyo_devs.sh
+++ b/scripts/list_hokuyo_devs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Usage: list_hokuyo_devs [options]
+#
+# Options:
+#   -v     Show device name with Hokuyo ID
+#   -h     Show help
+
+getopts "hv" opts
+if [ $opts == h ] ; then
+  sed -rn '/^# Usage/,${/^#/!q;s/^# ?//;p}' "$0"
+  exit 1 
+fi
+
+for dev in `ls /dev/ttyACM*` ; do
+  id=`timeout 1 rosrun hokuyo_node getID $dev -`
+  out_str=$dev
+
+  if [ $opts == v ] ; then
+    out_str="$out_str $id"
+  fi
+
+  if [ -n "$id" ] ; then
+    echo $out_str
+  fi
+done

--- a/scripts/list_hokuyo_devs.sh
+++ b/scripts/list_hokuyo_devs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Usage: list_hokuyo_devs [options]
+# Usage: ./list_hokuyo_devs.sh [options]
 #
 # Options:
 #   -v     Show device name with Hokuyo ID
@@ -13,7 +13,7 @@ if [ $opts == h ] ; then
 fi
 
 for dev in `ls /dev/ttyACM*` ; do
-  id=`timeout 1 rosrun hokuyo_node getID $dev -`
+  id=`timeout 2 rosrun hokuyo_node getID $dev -`
   out_str=$dev
 
   if [ $opts == v ] ; then


### PR DESCRIPTION
接続されているHokuyoのデバイスファイル名（ `/dev/ttyACM1` とかいうの）を列挙するスクリプトです。
これは実機で試す必要があります。

* 実行方法1
```
$(rospack find ubiquitous_display)/scripts/list_hokuyo_devs.sh
```

* 結果 （1つだけ接続されている場合の例）
```
/dev/ttyACM1

```

* 結果 （2つ接続されている場合の例）
```
/dev/ttyACM0
/dev/ttyACM1

```