### PR TITLE
依存パッケージを明示する

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -41,8 +41,15 @@
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>urdf</build_depend>
+  <build_depend>youbot_driver</build_depend>
+  <build_depend>youbot_driver_ros_interface</build_depend>
+  <build_depend>youbot_description</build_depend>
+  <build_depend>dynamixel_motor</build_depend>
   <run_depend>urdf</run_depend>
-
+  <run_depend>youbot_driver</run_depend>
+  <run_depend>youbot_driver_ros_interface</run_depend>
+  <run_depend>youbot_description</run_depend>
+  <run_depend>dynamixel_motor</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
`ros-indigo-desktop-full` には入ってないけど必須なパッケージって他にありましたっけ？