### PR TITLE
ud.urdfのmiddle_plateの親を修正する

### DIFF
--- a/urdf/ud.urdf.xacro
+++ b/urdf/ud.urdf.xacro
@@ -164,8 +164,8 @@
       <material name="white"/>
     </visual>
   </link>
-  <joint name="bottom_plate_to_middle_plate_joint" type="fixed">
-    <parent link="bottom_plate_link"/>
+  <joint name="middle_pillars_to_middle_plate_joint" type="fixed">
+    <parent link="middle_pillars_link"/>
     <child link="middle_plate_link"/>
     <origin xyz="0 0 ${middle_pillar_height}"/>
   </joint>


### PR DESCRIPTION
`ud.urdf.xacro` の `middle_plate_link` の親が `bottom_plate_link` になっていたので、  `middle_pillars_link` に修正しました。

## 修正前
```
[sakurai@ urdf]$ check_urdf old.urdf
robot name is: ud
---------- Successfully Parsed XML ---------------
root Link: base_footprint has 1 child(ren)
    child(1):  base_link
        child(1):  bottom_pillars_link
            child(1):  bottom_plate_link
                child(1):  base_laser_front_link
                child(2):  base_laser_rear_link
                child(3):  middle_pillars_link
                child(4):  middle_plate_link
                    child(1):  top_pillars_link
                        child(1):  top_plate_link
        child(2):  caster_link_bl
            child(1):  wheel_link_bl
        child(3):  caster_link_br
            child(1):  wheel_link_br
        child(4):  caster_link_fl
            child(1):  wheel_link_fl
        child(5):  caster_link_fr
            child(1):  wheel_link_fr
```

## 修正後
```
[sakurai@ urdf]$ check_urdf new.urdf
robot name is: ud
---------- Successfully Parsed XML ---------------
root Link: base_footprint has 1 child(ren)
    child(1):  base_link
        child(1):  bottom_pillars_link
            child(1):  bottom_plate_link
                child(1):  base_laser_front_link
                child(2):  base_laser_rear_link
                child(3):  middle_pillars_link
                    child(1):  middle_plate_link
                        child(1):  top_pillars_link
                            child(1):  top_plate_link
        child(2):  caster_link_bl
            child(1):  wheel_link_bl
        child(3):  caster_link_br
            child(1):  wheel_link_br
        child(4):  caster_link_fl
            child(1):  wheel_link_fl
        child(5):  caster_link_fr
            child(1):  wheel_link_fr
```