### PR TITLE
UD胴体部のURDFファイルを作成する

### DIFF
--- a/launch/show_body.launch
+++ b/launch/show_body.launch
@@ -1,0 +1,7 @@
+<launch>
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher"/>
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find ubiquitous_display)/rviz/show_body.rviz" required="true"/>
+
+  <param name="robot_description" command="$(find xacro)/xacro '$(find ubiquitous_display)/urdf/body.urdf.xacro'"/>
+</launch>

--- a/rviz/show_body.rviz
+++ b/rviz/show_body.rviz
@@ -1,0 +1,205 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+      Splitter Ratio: 0.5
+    Tree Height: 565
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 0.5
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.03
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        bottom_pillars_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bottom_plate_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_laser_adjuster_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        middle_pillars_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        middle_plate_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        rear_laser_adjuster_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        top_pillars_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        top_plate_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        bottom_pillars_link:
+          Value: true
+        bottom_plate_link:
+          Value: true
+        front_laser_adjuster_link:
+          Value: true
+        middle_pillars_link:
+          Value: true
+        middle_plate_link:
+          Value: true
+        rear_laser_adjuster_link:
+          Value: true
+        top_pillars_link:
+          Value: true
+        top_plate_link:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        bottom_pillars_link:
+          bottom_plate_link:
+            front_laser_adjuster_link:
+              {}
+            middle_pillars_link:
+              middle_plate_link:
+                top_pillars_link:
+                  top_plate_link:
+                    {}
+            rear_laser_adjuster_link:
+              {}
+      Update Interval: 0
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: bottom_pillars_link
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 1.93937
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.06
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.0317893
+        Y: -0.16627
+        Z: 0.235894
+      Name: Current View
+      Near Clip Distance: 0.01
+      Pitch: 0.495398
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 1.2704
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 846
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a000002befc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005300fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000034000002be000000b500fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002befc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730100000034000002be0000009700fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004f90000003efc0100000002fb0000000800540069006d00650100000000000004f90000020b00fffffffb0000000800540069006d0065010000000000000450000000000000000000000274000002be00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1273
+  X: 481
+  Y: 97

--- a/urdf/body.urdf.xacro
+++ b/urdf/body.urdf.xacro
@@ -4,7 +4,7 @@
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
        xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
        xmlns:xacro="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-       name="ud" >
+       name="body" >
 
   <!-- Definition of various sizes -->
   <property name="bottom_pillar_height" value="0.1"/>

--- a/urdf/body.urdf.xacro
+++ b/urdf/body.urdf.xacro
@@ -6,8 +6,6 @@
        xmlns:xacro="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
        name="ud" >
 
-  <!-- <xacro:include filename="$(find ubiquitous_display)/urdf/youbot_base_only.urdf.xacro" /> -->
-
   <!-- Definition of various sizes -->
   <property name="bottom_pillar_height" value="0.1"/>
   <property name="middle_pillar_height" value="0.157"/>
@@ -94,10 +92,6 @@
   <!-- Body -->
   <!-- Bottom part -->
   <xacro:tower_template name="bottom" pillar_height="${bottom_pillar_height}"/>
-  <!-- <joint name="base_to_bottom_pillars_joint" type="fixed"> -->
-  <!--   <parent link="base_link"/>                             -->
-  <!--   <child link="bottom_pillars_link"/>                    -->
-  <!-- </joint>                                                 -->
 
   <!-- Middle part -->
   <xacro:tower_template name="middle" pillar_height="${middle_pillar_height}"/>
@@ -113,25 +107,21 @@
     <child link="top_pillars_link"/>
   </joint>
 
-  <!-- base laser front -->
+  <!-- Laser adjusters -->
+  <!-- Front -->
   <xacro:laser_adjuster_template name="front"/>
   <joint name="front_laser_adjuster_joint" type="fixed">
     <origin xyz="${adjuster_offset_x} 0 0" rpy="0 0 0"/>
     <parent link="bottom_plate_link"/>
     <child link="front_laser_adjuster_link"/>
   </joint>
-  <!-- <xacro:hokuyo_urg04_laser name="base_laser_front" parent="front_laser_adjuster" ros_topic="base_scan" update_rate="10" min_angle="-1.57" max_angle="1.57"> -->
-  <!--   <origin xyz="${hokuyo_offset_x} 0 ${hokuyo_offset_z}" rpy="0 0 0"/>                                                                                      -->
-  <!-- </xacro:hokuyo_urg04_laser>                                                                                                                                -->
 
-  <!-- base laser rear -->
+  <!-- Rear -->
   <xacro:laser_adjuster_template name="rear"/>
   <joint name="rear_laser_adjuster_joint" type="fixed">
   <origin xyz="${-adjuster_offset_x} 0 0" rpy="0 0 3.1415"/>
   <parent link="bottom_plate_link"/>
   <child link="rear_laser_adjuster_link"/>
   </joint>
-  <!-- <xacro:hokuyo_urg04_laser name="base_laser_rear" parent="rear_laser_adjuster" ros_topic="base_scan" update_rate="10" min_angle="-1.57" max_angle="1.57"> -->
-  <!--   <origin xyz="${hokuyo_offset_x} 0 ${hokuyo_offset_z}" rpy="0 0 0"/>                                                                                    -->
-  <!-- </xacro:hokuyo_urg04_laser>                                                                                                                              -->
+
 </robot>

--- a/urdf/body.urdf.xacro
+++ b/urdf/body.urdf.xacro
@@ -1,0 +1,137 @@
+<?xml version="1.0"?>
+
+<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:xacro="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       name="ud" >
+
+  <!-- <xacro:include filename="$(find ubiquitous_display)/urdf/youbot_base_only.urdf.xacro" /> -->
+
+  <!-- Definition of various sizes -->
+  <property name="bottom_pillar_height" value="0.1"/>
+  <property name="middle_pillar_height" value="0.157"/>
+  <property name="top_pillar_height" value="0.435"/>
+  <property name="pillar_radius" value="0.01"/>
+  <property name="pillar_offset_x" value="0.21"/>
+  <property name="pillar_offset_y" value="0.06"/>
+  <property name="plate_len_x" value="0.5"/>
+  <property name="plate_len_y" value="0.2"/>
+  <property name="plate_len_z" value="0.004"/>
+  <property name="bar_len_x" value="0.18"/>
+  <property name="bar_len_y" value="0.02"/>
+  <property name="bar_len_z" value="0.02"/>
+  <property name="adjuster_width" value="0.05"/>
+  <property name="adjuster_offset_x" value="0.3"/>
+  <property name="hokuyo_offset_x" value="-0.05"/>
+  <property name="hokuyo_offset_z" value="0.037"/>
+
+  <!-- Definition of colors -->
+  <material name="black">
+    <color rgba="0 0 0 1"/>
+  </material>
+  <material name="white">
+    <color rgba="1 1 1 1"/>
+  </material>
+
+  <!-- Templates -->
+  <xacro:macro name="pillar_template" params="height origin_x origin_y">
+    <visual>
+      <geometry>
+        <cylinder length="${height}" radius="${pillar_radius}"/>
+      </geometry>
+      <origin xyz="${origin_x} ${origin_y} ${height/2}"/>
+      <material name="black"/>
+    </visual>
+  </xacro:macro>
+
+  <xacro:macro name="plate_template" params="name">
+    <link name="${name}_plate_link">
+      <visual>
+        <geometry>
+          <box size="${plate_len_x} ${plate_len_y} ${plate_len_z}"/>
+        </geometry>
+        <origin xyz="0 0 -${plate_len_z/2}"/>
+        <material name="white"/>
+      </visual>
+    </link>
+  </xacro:macro>
+  
+  <xacro:macro name="tower_template" params="name pillar_height">
+    <link name="${name}_pillars_link">
+      <xacro:pillar_template height="${pillar_height}" origin_x="${pillar_offset_x}" origin_y="${pillar_offset_y}"/>
+      <xacro:pillar_template height="${pillar_height}" origin_x="${-pillar_offset_x}" origin_y="${pillar_offset_y}"/>
+      <xacro:pillar_template height="${pillar_height}" origin_x="${pillar_offset_x}" origin_y="${-pillar_offset_y}"/>
+      <xacro:pillar_template height="${pillar_height}" origin_x="${-pillar_offset_x}" origin_y="${-pillar_offset_y}"/>
+    </link>
+    <xacro:plate_template name="${name}"/>
+    <joint name="${name}_pillars_to_${name}_plate_joint" type="fixed">
+      <parent link="${name}_pillars_link"/>
+      <child link="${name}_plate_link"/>
+      <origin xyz="0 0 ${pillar_height}"/>
+    </joint>
+  </xacro:macro>
+
+  <xacro:macro name="laser_adjuster_template" params="name">
+    <link name="${name}_laser_adjuster_link">
+      <visual>
+        <geometry>
+          <box size="${bar_len_x} ${bar_len_y} ${bar_len_z}"/>
+        </geometry>
+        <origin xyz="${-bar_len_x/2} ${adjuster_width/2} ${bar_len_z/2}"/>
+        <material name="white" />
+      </visual>
+      <visual>
+        <geometry>
+          <box size="${bar_len_x} ${bar_len_y} ${bar_len_z}"/>
+        </geometry>
+        <origin xyz="${-bar_len_x/2} ${-adjuster_width/2} ${bar_len_z/2}"/>
+        <material name="white" />
+      </visual>
+    </link>
+  </xacro:macro>
+
+  <!-- Body -->
+  <!-- Bottom part -->
+  <xacro:tower_template name="bottom" pillar_height="${bottom_pillar_height}"/>
+  <!-- <joint name="base_to_bottom_pillars_joint" type="fixed"> -->
+  <!--   <parent link="base_link"/>                             -->
+  <!--   <child link="bottom_pillars_link"/>                    -->
+  <!-- </joint>                                                 -->
+
+  <!-- Middle part -->
+  <xacro:tower_template name="middle" pillar_height="${middle_pillar_height}"/>
+  <joint name="bottom_plate_to_middle_pillars_joint" type="fixed">
+    <parent link="bottom_plate_link"/>
+    <child link="middle_pillars_link"/>
+  </joint>
+
+  <!-- Top part -->
+  <xacro:tower_template name="top" pillar_height="${top_pillar_height}"/>
+  <joint name="middle_plate_to_top_pillars_joint" type="fixed">
+    <parent link="middle_plate_link"/>
+    <child link="top_pillars_link"/>
+  </joint>
+
+  <!-- base laser front -->
+  <xacro:laser_adjuster_template name="front"/>
+  <joint name="front_laser_adjuster_joint" type="fixed">
+    <origin xyz="${adjuster_offset_x} 0 0" rpy="0 0 0"/>
+    <parent link="bottom_plate_link"/>
+    <child link="front_laser_adjuster_link"/>
+  </joint>
+  <!-- <xacro:hokuyo_urg04_laser name="base_laser_front" parent="front_laser_adjuster" ros_topic="base_scan" update_rate="10" min_angle="-1.57" max_angle="1.57"> -->
+  <!--   <origin xyz="${hokuyo_offset_x} 0 ${hokuyo_offset_z}" rpy="0 0 0"/>                                                                                      -->
+  <!-- </xacro:hokuyo_urg04_laser>                                                                                                                                -->
+
+  <!-- base laser rear -->
+  <xacro:laser_adjuster_template name="rear"/>
+  <joint name="rear_laser_adjuster_joint" type="fixed">
+  <origin xyz="${-adjuster_offset_x} 0 0" rpy="0 0 3.1415"/>
+  <parent link="bottom_plate_link"/>
+  <child link="rear_laser_adjuster_link"/>
+  </joint>
+  <!-- <xacro:hokuyo_urg04_laser name="base_laser_rear" parent="rear_laser_adjuster" ros_topic="base_scan" update_rate="10" min_angle="-1.57" max_angle="1.57"> -->
+  <!--   <origin xyz="${hokuyo_offset_x} 0 ${hokuyo_offset_z}" rpy="0 0 0"/>                                                                                    -->
+  <!-- </xacro:hokuyo_urg04_laser>                                                                                                                              -->
+</robot>


### PR DESCRIPTION
`urdf/ud.urdf.xacro` から胴体部の記述を別ファイルに分離するために、胴体部のURDFファイルを作成しました。
元のURDFに対して以下の点で変更があります:
* マクロ化した
* hokuyoを載せるところを、 `laser_adjuster` という別リンクにした

以下のコマンドで視覚化できます。
```
roslaunch ubiquitous_display show_body.launch
```

`rear_laser_adjuster_link` は、後ろ方向がx軸の正方向としてみたのですが、どうなんでしょうか？

```
[sakurai@ ubiquitous_display]$ check_urdf urdf/body.urdf
robot name is: ud
---------- Successfully Parsed XML ---------------
root Link: bottom_pillars_link has 1 child(ren)
    child(1):  bottom_plate_link
        child(1):  middle_pillars_link
            child(1):  middle_plate_link
                child(1):  top_pillars_link
                    child(1):  top_plate_link
        child(2):  front_laser_adjuster_link
        child(3):  rear_laser_adjuster_link
```