### PR TITLE
pantilt.urdfで定義されている色名が競合しているため別名に変更する

### DIFF
--- a/urdf/pantilt.urdf.xacro
+++ b/urdf/pantilt.urdf.xacro
@@ -18,7 +18,7 @@
   <material name="green" >
     <color rgba="0.0 0.7 0.7 1.0" />
   </material>
-  <material name="white" >
+  <material name="gray" >
     <color rgba="0.7 0.7 0.7 1.0" />
   </material>
 
@@ -49,7 +49,7 @@
         <geometry>
           <box size="0.24 0.17 0.07" />
         </geometry>
-        <material name="white"/>
+        <material name="gray"/>
       </visual>
     </link>
 


### PR DESCRIPTION
UDのURDFにパンチルトを統合しようとしたところ、  `material` の定義に重複があるらしく、 `robot_state_publisher` が以下のエラーを吐くため起動できません。
そのため、 `white` と定義されている色名を `gray` に変更しました。

```
[ERROR] [1481793464.822225543]: material 'white' is not unique.
[robot_state_publisher-2] process has died [pid 9387, exit code -11, cmd /opt/ros/indigo/lib/robot_state_publisher/robot_state_publisher __name:=robot_state_publisher __log:=/home/sakurai/.ros/log/560d95dc-c2a7-11e6-8bc3-00155d650c00/robot_state_publisher-2.log].
```

`body.urdf.xacro` のほうでも `<material name="white">` を定義しており、試しにそちらをリネームした場合には競合が解消せず、 `pantilt.urdf.xacro` のほうをリネームした場合にだけ解消されました。