### PR TITLE
[要#37マージ後に競合解消] youbot, body, pantiltを統合するURDF

### DIFF
--- a/launch/README.md
+++ b/launch/README.md
@@ -1,3 +1,10 @@
+### show_ud.launch
+UDのURDF (urdf/ud.urdf.xacro) をrvizで表示する(関節操作GUI付き)。
+
+```
+roslaunch ubiquitous_display show_ud.launch
+```
+
 ### show_youbot.launch
 UDのURDF (urdf/ud.urdf.xacro) をrvizで表示する。
 

--- a/launch/show_ud.launch
+++ b/launch/show_ud.launch
@@ -1,0 +1,9 @@
+<launch>
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+    <param name="use_gui" value="true"/>
+  </node>
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find ubiquitous_display)/rviz/show_youbot.rviz" required="true"/>
+
+  <param name="robot_description" command="$(find xacro)/xacro '$(find ubiquitous_display)/urdf/ud.urdf.xacro'"/>
+</launch>

--- a/rviz/show_youbot.rviz
+++ b/rviz/show_youbot.rviz
@@ -68,7 +68,22 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
+        base_laser_rear_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
         base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bottom_pillars_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bottom_plate_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -89,6 +104,55 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
+        front_laser_adjuster_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        middle_pillars_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        middle_plate_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        rear_laser_adjuster_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        top_pillars_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        top_plate_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ud_pt_base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        ud_pt_box_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ud_pt_plate_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ud_pt_projector_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
         wheel_link_bl:
           Alpha: 1
           Show Axes: false
@@ -124,7 +188,13 @@ Visualization Manager:
           Value: true
         base_laser_front_link:
           Value: true
+        base_laser_rear_link:
+          Value: true
         base_link:
+          Value: true
+        bottom_pillars_link:
+          Value: true
+        bottom_plate_link:
           Value: true
         caster_link_bl:
           Value: true
@@ -133,6 +203,26 @@ Visualization Manager:
         caster_link_fl:
           Value: true
         caster_link_fr:
+          Value: true
+        front_laser_adjuster_link:
+          Value: true
+        middle_pillars_link:
+          Value: true
+        middle_plate_link:
+          Value: true
+        rear_laser_adjuster_link:
+          Value: true
+        top_pillars_link:
+          Value: true
+        top_plate_link:
+          Value: true
+        ud_pt_base_link:
+          Value: true
+        ud_pt_box_link:
+          Value: true
+        ud_pt_plate_link:
+          Value: true
+        ud_pt_projector_link:
           Value: true
         wheel_link_bl:
           Value: true
@@ -150,8 +240,23 @@ Visualization Manager:
       Tree:
         base_footprint:
           base_link:
-            base_laser_front_link:
-              {}
+            bottom_pillars_link:
+              bottom_plate_link:
+                front_laser_adjuster_link:
+                  base_laser_front_link:
+                    {}
+                middle_pillars_link:
+                  middle_plate_link:
+                    top_pillars_link:
+                      top_plate_link:
+                        ud_pt_base_link:
+                          ud_pt_box_link:
+                            ud_pt_plate_link:
+                              ud_pt_projector_link:
+                                {}
+                rear_laser_adjuster_link:
+                  base_laser_rear_link:
+                    {}
             caster_link_bl:
               wheel_link_bl:
                 {}
@@ -197,15 +302,15 @@ Visualization Manager:
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: 0
-        Y: 0
-        Z: 0
+        X: 0.00716881
+        Y: -0.0481524
+        Z: 0.462527
       Name: Current View
       Near Clip Distance: 0.01
-      Pitch: 0.575398
+      Pitch: 0.480398
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 0.820398
+      Yaw: 4.43858
     Saved: ~
 Window Geometry:
   Displays:
@@ -213,7 +318,7 @@ Window Geometry:
   Height: 846
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000016a000002c4fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006400fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000028000002c4000000dd00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002c4fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730100000028000002c4000000b000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004f90000003efc0100000002fb0000000800540069006d00650100000000000004f9000002f600fffffffb0000000800540069006d0065010000000000000450000000000000000000000274000002c400000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a000002befc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005300fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000034000002be000000b500fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002befc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730100000034000002be0000009700fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004f90000003efc0100000002fb0000000800540069006d00650100000000000004f90000020b00fffffffb0000000800540069006d0065010000000000000450000000000000000000000274000002be00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:

--- a/urdf/ud.urdf.xacro
+++ b/urdf/ud.urdf.xacro
@@ -8,6 +8,7 @@
 
   <xacro:include filename="$(find ubiquitous_display)/urdf/youbot_base_only.urdf.xacro" />
   <xacro:include filename="$(find ubiquitous_display)/urdf/body.urdf.xacro" />
+  <xacro:include filename="$(find ubiquitous_display)/urdf/pantilt.urdf.xacro" />
 
   <property name="hokuyo_offset_x" value="-0.05"/>
   <property name="hokuyo_offset_z" value="0.037"/>
@@ -16,6 +17,12 @@
     <ogirin xyz="0 0 0" rpy="0 0 0"/>
     <parent link="base_link"/>
     <child link="bottom_pillars_link"/>
+  </joint>
+
+  <joint name="body_to_pantilt_joint" type="fixed">
+    <ogirin xyz="0 0 0" rpy="0 0 0"/>
+    <parent link="top_plate_link"/>
+    <child link="ud_pt_base_link"/>
   </joint>
 
   <!-- base laser front -->
@@ -27,4 +34,5 @@
   <xacro:hokuyo_urg04_laser name="base_laser_rear" parent="rear_laser_adjuster" ros_topic="base_scan" update_rate="10" min_angle="-1.57" max_angle="1.57">
     <origin xyz="${hokuyo_offset_x} 0 ${hokuyo_offset_z}" rpy="0 0 0"/>
   </xacro:hokuyo_urg04_laser>
+
 </robot>

--- a/urdf/ud.urdf.xacro
+++ b/urdf/ud.urdf.xacro
@@ -7,227 +7,24 @@
        name="ud" >
 
   <xacro:include filename="$(find ubiquitous_display)/urdf/youbot_base_only.urdf.xacro" />
+  <xacro:include filename="$(find ubiquitous_display)/urdf/body.urdf.xacro" />
 
-  <!-- Definition of various sizes -->
-  <property name="bottom_pillar_height" value="0.1"/>
-  <property name="middle_pillar_height" value="0.157"/>
-  <property name="top_pillar_height" value="0.435"/>
-  <property name="pillar_radius" value="0.01"/>
-  <property name="pillar_offset_x" value="0.21"/>
-  <property name="pillar_offset_y" value="0.06"/>
-  <property name="plate_len_x" value="0.5"/>
-  <property name="plate_len_y" value="0.2"/>
-  <property name="plate_len_z" value="0.004"/>
-  <property name="bar_len_x" value="0.18"/>
-  <property name="bar_len_y" value="0.02"/>
-  <property name="bar_len_z" value="0.02"/>
-  <property name="hokuyo_offset_x" value="0.25"/>
+  <property name="hokuyo_offset_x" value="-0.05"/>
   <property name="hokuyo_offset_z" value="0.037"/>
 
-  <!-- Definition of colors -->
-  <material name="black">
-    <color rgba="0 0 0 1"/>
-  </material>
-  <material name="white">
-    <color rgba="1 1 1 1"/>
-  </material>
-
-  <!-- Body -->
-  <!-- Bottom part -->
-  <link name="bottom_pillars_link">
-    <visual>
-      <geometry>
-        <cylinder length="${bottom_pillar_height}" radius="${pillar_radius}"/>
-      </geometry>
-      <origin xyz="${pillar_offset_x} ${pillar_offset_y} ${bottom_pillar_height/2}"/>
-      <material name="black"/>
-    </visual>
-    <visual>
-      <geometry>
-        <cylinder length="${bottom_pillar_height}" radius="${pillar_radius}"/>
-      </geometry>
-      <origin xyz="-${pillar_offset_x} ${pillar_offset_y} ${bottom_pillar_height/2}"/>
-      <material name="black"/>
-    </visual>
-    <visual>
-      <geometry>
-        <cylinder length="${bottom_pillar_height}" radius="${pillar_radius}"/>
-      </geometry>
-      <origin xyz="${pillar_offset_x} -${pillar_offset_y} ${bottom_pillar_height/2}"/>
-      <material name="black"/>
-    </visual>
-    <visual>
-      <geometry>
-        <cylinder length="${bottom_pillar_height}" radius="${pillar_radius}"/>
-      </geometry>
-      <origin xyz="-${pillar_offset_x} -${pillar_offset_y} ${bottom_pillar_height/2}"/>
-      <material name="black"/>
-    </visual>
-  </link>
-  <joint name="base_to_bottom_pillars_joint" type="fixed">
+  <joint name="youbot_to_body_joint" type="fixed">
+    <ogirin xyz="0 0 0" rpy="0 0 0"/>
     <parent link="base_link"/>
     <child link="bottom_pillars_link"/>
   </joint>
 
-  <link name="bottom_plate_link">
-    <visual>
-      <geometry>
-        <box size="${plate_len_x} ${plate_len_y} ${plate_len_z}"/>
-      </geometry>
-      <origin xyz="0 0 -${plate_len_z/2}"/>
-      <material name="white"/>
-    </visual>
-    <visual>
-      <geometry>
-        <box size="${bar_len_x} ${bar_len_y} ${bar_len_z}"/>
-      </geometry>
-      <origin xyz="0.20 0.025 ${bar_len_z/2}"/>
-     <material name="gray" />
-    </visual>
-    <visual>
-      <geometry>
-        <box size="${bar_len_x} ${bar_len_y} ${bar_len_z}"/>
-      </geometry>
-      <origin xyz="0.20 -0.025 ${bar_len_z/2}"/>
-     <material name="gray" />
-    </visual>
-    <visual>
-      <geometry>
-        <box size="${bar_len_x} ${bar_len_y} ${bar_len_z}"/>
-      </geometry>
-      <origin xyz="-0.20 0.025 ${bar_len_z/2}"/>
-     <material name="gray" />
-    </visual>
-    <visual>
-      <geometry>
-        <box size="${bar_len_x} ${bar_len_y} ${bar_len_z}"/>
-      </geometry>
-      <origin xyz="-0.20 0.025 ${bar_len_z/2}"/>
-     <material name="gray" />
-    </visual>
-    <visual>
-      <geometry>
-        <box size="${bar_len_x} ${bar_len_y} ${bar_len_z}"/>
-      </geometry>
-      <origin xyz="-0.20 -0.025 ${bar_len_z/2}"/>
-     <material name="gray" />
-    </visual>
-  </link>
-  <joint name="bottom_pillars_to_bottom_plate_joint" type="fixed">
-    <parent link="bottom_pillars_link"/>
-    <child link="bottom_plate_link"/>
-    <origin xyz="0 0 ${bottom_pillar_height}"/>
-  </joint>
-
- <!-- Middle part -->
-  <link name="middle_pillars_link">
-    <visual>
-      <geometry>
-        <cylinder length="${middle_pillar_height}" radius="${pillar_radius}"/>
-      </geometry>
-      <origin xyz="${pillar_offset_x} ${pillar_offset_y} ${middle_pillar_height/2}"/>
-      <material name="black"/>
-    </visual>
-    <visual>
-      <geometry>
-        <cylinder length="${middle_pillar_height}" radius="${pillar_radius}"/>
-      </geometry>
-      <origin xyz="-${pillar_offset_x} ${pillar_offset_y} ${middle_pillar_height/2}"/>
-      <material name="black"/>
-    </visual>
-    <visual>
-      <geometry>
-        <cylinder length="${middle_pillar_height}" radius="${pillar_radius}"/>
-      </geometry>
-      <origin xyz="${pillar_offset_x} -${pillar_offset_y} ${middle_pillar_height/2}"/>
-      <material name="black"/>
-    </visual>
-    <visual>
-      <geometry>
-        <cylinder length="${middle_pillar_height}" radius="${pillar_radius}"/>
-      </geometry>
-      <origin xyz="-${pillar_offset_x} -${pillar_offset_y} ${middle_pillar_height/2}"/>
-      <material name="black"/>
-    </visual>
-  </link>
-  <joint name="bottom_plate_to_middle_pillars_joint" type="fixed">
-    <parent link="bottom_plate_link"/>
-    <child link="middle_pillars_link"/>
-  </joint>
-
-  <link name="middle_plate_link">
-    <visual>
-      <geometry>
-        <box size="${plate_len_x} ${plate_len_y} ${plate_len_z}"/>
-      </geometry>
-      <origin xyz="0 0 -${plate_len_z/2}"/>
-      <material name="white"/>
-    </visual>
-  </link>
-  <joint name="middle_pillars_to_middle_plate_joint" type="fixed">
-    <parent link="middle_pillars_link"/>
-    <child link="middle_plate_link"/>
-    <origin xyz="0 0 ${middle_pillar_height}"/>
-  </joint>
-
-  <!-- Top part -->
-  <link name="top_pillars_link">
-    <visual>
-      <geometry>
-        <cylinder length="${top_pillar_height}" radius="${pillar_radius}"/>
-      </geometry>
-      <origin xyz="${pillar_offset_x} ${pillar_offset_y} ${top_pillar_height/2}"/>
-      <material name="black"/>
-    </visual>
-    <visual>
-      <geometry>
-        <cylinder length="${top_pillar_height}" radius="${pillar_radius}"/>
-      </geometry>
-      <origin xyz="-${pillar_offset_x} ${pillar_offset_y} ${top_pillar_height/2}"/>
-      <material name="black"/>
-    </visual>
-    <visual>
-      <geometry>
-        <cylinder length="${top_pillar_height}" radius="${pillar_radius}"/>
-      </geometry>
-      <origin xyz="${pillar_offset_x} -${pillar_offset_y} ${top_pillar_height/2}"/>
-      <material name="black"/>
-    </visual>
-    <visual>
-      <geometry>
-        <cylinder length="${top_pillar_height}" radius="${pillar_radius}"/>
-      </geometry>
-      <origin xyz="-${pillar_offset_x} -${pillar_offset_y} ${top_pillar_height/2}"/>
-      <material name="black"/>
-    </visual>
-  </link>
-  <joint name="middle_plate_to_top_pillars_joint" type="fixed">
-    <parent link="middle_plate_link"/>
-    <child link="top_pillars_link"/>
-  </joint>
-
-  <link name="top_plate_link">
-    <visual>
-      <geometry>
-        <box size="${plate_len_x} ${plate_len_y} ${plate_len_z}"/>
-      </geometry>
-      <origin xyz="0 0 -${plate_len_z/2}"/>
-      <material name="white"/>
-    </visual>
-  </link>
-  <joint name="top_pillars_to_top_plate_joint" type="fixed">
-    <parent link="top_pillars_link"/>
-    <child link="top_plate_link"/>
-    <origin xyz="0 0 ${top_pillar_height}"/>
-  </joint>
-
   <!-- base laser front -->
-  <xacro:hokuyo_urg04_laser name="base_laser_front" parent="bottom_plate" ros_topic="base_scan" update_rate="10" min_angle="-1.57" max_angle="1.57">
+  <xacro:hokuyo_urg04_laser name="base_laser_front" parent="front_laser_adjuster" ros_topic="base_scan" update_rate="10" min_angle="-1.57" max_angle="1.57">
     <origin xyz="${hokuyo_offset_x} 0 ${hokuyo_offset_z}" rpy="0 0 0"/>
   </xacro:hokuyo_urg04_laser>
 
   <!-- base laser rear -->
-  <xacro:hokuyo_urg04_laser name="base_laser_rear" parent="bottom_plate" ros_topic="base_scan" update_rate="10" min_angle="-1.57" max_angle="1.57">
-    <origin xyz="-${hokuyo_offset_x} 0 ${hokuyo_offset_z}" rpy="0 0 3.14"/>
+  <xacro:hokuyo_urg04_laser name="base_laser_rear" parent="rear_laser_adjuster" ros_topic="base_scan" update_rate="10" min_angle="-1.57" max_angle="1.57">
+    <origin xyz="${hokuyo_offset_x} 0 ${hokuyo_offset_z}" rpy="0 0 0"/>
   </xacro:hokuyo_urg04_laser>
 </robot>


### PR DESCRIPTION
`ud.urdf.xacro` でyoubot, body, pantiltを統合します。

```
roslaunch launch/show_ud.launch
```
で以下のような感じに表示されます。画面の右側が前方（壁側）です。
![screenshot from 2016-12-17 14 05 10](https://cloud.githubusercontent.com/assets/142082/21284549/0ee97664-c462-11e6-8775-4c60934d6d18.png)

関節操作GUIも出るようになってますが、パンとチルトを動かしてみたところ、可動範囲や設置方向などがおかしいような気がします。ただ、その修正は別PRにしたいと思います。